### PR TITLE
PP-11226: Allow setting the open telemetry log level as an env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM amazon/aws-otel-collector:v0.31.0
 
+ENV OTEL_LOG_LEVEL=INFO
+
 COPY config.yml /etc/ecs/govuk-pay-adot-sidecar-config.yaml
 
 CMD ["--config=/etc/ecs/govuk-pay-adot-sidecar-config.yaml"]

--- a/config.yml
+++ b/config.yml
@@ -31,6 +31,9 @@ extensions:
       arn: $PROMETHEUS_WRITE_ASSUME_ROLE_ARN
 
 service:
+  telemetry:
+    logs:
+      level: $OTEL_LOG_LEVEL
   extensions: [sigv4auth]
   pipelines:
     metrics/application:

--- a/tests/test-config.yml
+++ b/tests/test-config.yml
@@ -21,6 +21,9 @@ exporters:
     loglevel: info
 
 service:
+  telemetry:
+    logs:
+      level: $OTEL_LOG_LEVEL
   pipelines:
     metrics/application:
       receivers: [prometheus]


### PR DESCRIPTION
Setting this to DEBUG and running the included tests shows debug logs:

```
$ docker-compose  logs adot-sidecar
tests-adot-sidecar-1  | 2023/08/09 11:01:26 ADOT Collector version: v0.31.0
tests-adot-sidecar-1  | 2023/08/09 11:01:26 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
tests-adot-sidecar-1  | 2023-08-09T11:01:26.835Z	info	service/telemetry.go:81	Setting up own telemetry...
tests-adot-sidecar-1  | 2023-08-09T11:01:26.835Z	info	service/telemetry.go:104	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.835Z	info	exporter@v0.80.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "logging"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.835Z	warn	loggingexporter@v0.80.0/factory.go:98	'loglevel' option is deprecated in favor of 'verbosity'. Set 'verbosity' to equivalent value to preserve behavior.	{"kind": "exporter", "data_type": "metrics", "name": "logging", "loglevel": "info", "equivalent verbosity level": "Normal"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.836Z	debug	exporter@v0.80.0/exporter.go:273	Beta component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "prometheusremotewrite"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.836Z	debug	receiver@v0.80.0/receiver.go:294	Beta component. May change in the future.	{"kind": "receiver", "name": "prometheus", "data_type": "metrics"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	service/service.go:131	Starting aws-otel-collector...	{"Version": "v0.31.0", "NumCPU": 6}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	extensions/extensions.go:30	Starting extensions...
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:242	Starting discovery manager	{"kind": "receiver", "name": "prometheus", "data_type": "metrics"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:233	Scrape job added	{"kind": "receiver", "name": "prometheus", "data_type": "metrics", "jobName": "adot-sidecar-scrape-application"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	debug	discovery/manager.go:289	Starting provider	{"kind": "receiver", "name": "prometheus", "data_type": "metrics", "provider": "static/0", "subs": "map[adot-sidecar-scrape-application:{}]"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	service/service.go:148	Everything is ready. Begin running and processing data.
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:281	Starting scrape manager	{"kind": "receiver", "name": "prometheus", "data_type": "metrics"}
tests-adot-sidecar-1  | 2023-08-09T11:01:26.837Z	debug	discovery/manager.go:323	Discoverer channel closed	{"kind": "receiver", "name": "prometheus", "data_type": "metrics", "provider": "static/0"}
tests-adot-sidecar-1  | 2023-08-09T11:01:41.797Z	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 38, "data points": 68}
tests-adot-sidecar-1  | 2023-08-09T11:01:56.794Z	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 38, "data points": 68
```

compared with the default showing INFO:
```
$ docker-compose  logs adot-sidecar
tests-adot-sidecar-1  | 2023/08/09 11:02:43 ADOT Collector version: v0.31.0
tests-adot-sidecar-1  | 2023/08/09 11:02:43 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
tests-adot-sidecar-1  | 2023-08-09T11:02:43.650Z	info	service/telemetry.go:81	Setting up own telemetry...
tests-adot-sidecar-1  | 2023-08-09T11:02:43.651Z	info	service/telemetry.go:104	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.651Z	info	exporter@v0.80.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "logging"}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.651Z	warn	loggingexporter@v0.80.0/factory.go:98	'loglevel' option is deprecated in favor of 'verbosity'. Set 'verbosity' to equivalent value to preserve behavior.	{"kind": "exporter", "data_type": "metrics", "name": "logging", "loglevel": "info", "equivalent verbosity level": "Normal"}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.652Z	info	service/service.go:131	Starting aws-otel-collector...	{"Version": "v0.31.0", "NumCPU": 6}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.652Z	info	extensions/extensions.go:30	Starting extensions...
tests-adot-sidecar-1  | 2023-08-09T11:02:43.653Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:242	Starting discovery manager	{"kind": "receiver", "name": "prometheus", "data_type": "metrics"}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.653Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:233	Scrape job added	{"kind": "receiver", "name": "prometheus", "data_type": "metrics", "jobName": "adot-sidecar-scrape-application"}
tests-adot-sidecar-1  | 2023-08-09T11:02:43.653Z	info	service/service.go:148	Everything is ready. Begin running and processing data.
tests-adot-sidecar-1  | 2023-08-09T11:02:43.653Z	info	prometheusreceiver@v0.80.0/metrics_receiver.go:281	Starting scrape manager	{"kind": "receiver", "name": "prometheus", "data_type": "metrics"}
tests-adot-sidecar-1  | 2023-08-09T11:02:49.653Z	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 38, "data points": 66}
tests-adot-sidecar-1  | 2023-08-09T11:03:04.652Z	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 38, "data points": 68}
```