### PR TITLE
PP-11226: Disable otel internal telemetry metrics

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -34,6 +34,8 @@ service:
   telemetry:
     logs:
       level: $OTEL_LOG_LEVEL
+    metrics:
+      level: none
   extensions: [sigv4auth]
   pipelines:
     metrics/application:

--- a/tests/test-config.yml
+++ b/tests/test-config.yml
@@ -24,6 +24,8 @@ service:
   telemetry:
     logs:
       level: $OTEL_LOG_LEVEL
+    metrics:
+      level: none
   pipelines:
     metrics/application:
       receivers: [prometheus]


### PR DESCRIPTION
We won't be scraping the internal metrics of the telemetry service, and it conflicts in port number with some of our already deployed services, so to reduce resource usage and make our lives simpler lets disable the daemon.

You can see this locally where I exposed the port 8888:

Without the metrics level left as default:

* Start the adot container
```
$ docker-compose up -d adot-sidecar
[+] Running 4/4
 ✔ Network tests_default           Created                                                                                                                                                                                                                                                                                                                                                                       0.0s
 ✔ Container tests-test-app-1      Started                                                                                                                                                                                                                                                                                                                                                                       0.3s
 ✔ Container tests-prometheus-1    Started                                                                                                                                                                                                                                                                                                                                                                       0.4s
 ✔ Container tests-adot-sidecar-1  Started                                                                                                                                                                                                                                                                                                                                                                       0.5s
```

* Telnet to the exposed port. You can see I was able to establish a connection and have a conversation (which resulted in an HTTP 400
```
14:26 : GDS10799 : no_aws : (pp-11226/disable-internal-otel-metrics) : [~/gitdevel/github.com/alphagov/pay-adot/tests]
♥ $ telnet localhost 8888
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
foo
HTTP/1.1 400 Bad Request
Content-Type: text/plain; charset=utf-8
Connection: close

400 Bad RequestConnection closed by foreign host.
```

Then when I set the config of telemetry metrics level to none:

* start the adot sidecar
```
14:26 : GDS10799 : no_aws : (pp-11226/disable-internal-otel-metrics) : [~/gitdevel/github.com/alphagov/pay-adot/tests]
♥ $ docker-compose up -d adot-sidecar
[+] Running 4/4
 ✔ Network tests_default           Created                                                                                                                                                                                                                                                                                                                                                                       0.0s
 ✔ Container tests-test-app-1      Started                                                                                                                                                                                                                                                                                                                                                                       0.2s
 ✔ Container tests-prometheus-1    Started                                                                                                                                                                                                                                                                                                                                                                       0.2s
 ✔ Container tests-adot-sidecar-1  Started                                                                                                                                                                                                                                                                                                                                                                       0.3s
```

* Now I cannot connect to port 8888
```
14:26 : GDS10799 : no_aws : (pp-11226/disable-internal-otel-metrics) : [~/gitdevel/github.com/alphagov/pay-adot/tests]
♥ $ telnet localhost 8888
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
Connection closed by foreign host.
```