### PR TITLE
PP-11226: Update scrape interval to 30s

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@ receivers:
   prometheus:
     config:
       global:
-        scrape_interval: 15s
+        scrape_interval: 30s
         scrape_timeout: 10s
       scrape_configs:
       - job_name: "adot-sidecar-scrape-application"


### PR DESCRIPTION
Reduce scrape interval to 30 seconds. This is an acceptable delay and halves our costs for ingestion (the vast bulk of the cost in using AMP) which makes this better use of public money.