### PR TITLE
PP-11548: Add default labels from env and ecs resourcedetection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-otel-collector:v0.32.0
+FROM amazon/aws-otel-collector:v0.33.0
 
 ENV OTEL_LOG_LEVEL=INFO
 

--- a/config.yml
+++ b/config.yml
@@ -12,16 +12,72 @@ receivers:
         honor_timestamps: true
 
 processors:
+  resourcedetection/env:
+    detectors: [env]
+    timeout: 2s
+    override: true
+
+  resourcedetection/ecs:
+    detectors: [ecs]
+    timeout: 2s
+    override: true
+
+  resource/deleteUnrequired:
+    attributes:
+      - key: net.host.name
+        action: delete
+      - key: net.host.port
+        action: delete
+      - key: service.instance.id
+        action: delete
+      - key: service.name
+        action: delete
+      - key: http.scheme
+        action: delete
+      - key: cloud.provider
+        action: delete
+      - key: cloud.platform
+        action: delete
+      - key: cloud.account.id
+        action: delete
+      - key: cloud.region
+        action: delete
+      - key: cloud.availability_zone
+        action: delete
+      - key: aws.ecs.cluster.arn
+        action: delete
+      - key: aws.ecs.task.family
+        action: delete
+      - key: aws.ecs.task.revision
+        action: delete
+      - key: aws.ecs.launchtype
+        action: delete
+      - key: aws.log.group.names
+        action: delete
+      - key: aws.log.group.arns
+        action: delete
+      - key: aws.log.stream.names
+        action: delete
+      - key: aws.log.stream.arns
+        action: delete
+
+  resource/rename:
+    attributes:
+      - key: ecsTaskARN
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: aws.ecs.task.arn
+        action: delete
 
 exporters:
   prometheusremotewrite:
     endpoint: $PROMETHEUS_ENDPOINT_URL
     resource_to_telemetry_conversion:
-        enabled: false
+        enabled: true
     auth:
       authenticator: sigv4auth
   logging:
-    loglevel: info
+    verbosity: normal
 
 extensions:
   sigv4auth:
@@ -39,5 +95,13 @@ service:
   extensions: [sigv4auth]
   pipelines:
     metrics/application:
-      receivers: [prometheus]
-      exporters: [logging, prometheusremotewrite]
+      receivers:
+        - prometheus
+      processors:
+        - resourcedetection/env
+        - resourcedetection/ecs
+        - resource/deleteUnrequired
+        - resource/rename
+      exporters:
+        - logging
+        - prometheusremotewrite

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - APPLICATION_PORT=3000
       - PROMETHEUS_REMOTE_WRITE_URL=http://prometheus:9090/api/v1/write
+      - OTEL_RESOURCE_ATTRIBUTES=fooLabel=fooValue
  
   prometheus:
     image: prom/prometheus:v2.45.0

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - APPLICATION_PORT=3000
       - PROMETHEUS_REMOTE_WRITE_URL=http://prometheus:9090/api/v1/write
-      - OTEL_RESOURCE_ATTRIBUTES=fooLabel=fooValue
+      - OTEL_RESOURCE_ATTRIBUTES=fooLabel=fooValue,fooLabel2=fooValue2
  
   prometheus:
     image: prom/prometheus:v2.45.0

--- a/tests/test-config.yml
+++ b/tests/test-config.yml
@@ -12,13 +12,40 @@ receivers:
         honor_labels: true
         honor_timestamps: true
 
+processors:
+  resourcedetection/env:
+    detectors: [env]
+    timeout: 2s
+    override: true
+
+  resource/deleteUnrequired:
+    attributes:
+      - key: net.host.name
+        action: delete
+      - key: net.host.port
+        action: delete
+      - key: service.instance.id
+        action: delete
+      - key: service.name
+        action: delete
+      - key: http.scheme
+        action: delete
+
+  resource/rename:
+    attributes:
+      - key: barLabel
+        from_attribute: fooLabel
+        action: insert
+      - key: fooLabel
+        action: delete
+
 exporters:
   prometheusremotewrite:
     endpoint: $PROMETHEUS_REMOTE_WRITE_URL
     resource_to_telemetry_conversion:
-        enabled: false
+        enabled: true
   logging:
-    loglevel: info
+    verbosity: normal
 
 service:
   telemetry:
@@ -28,5 +55,12 @@ service:
       level: none
   pipelines:
     metrics/application:
-      receivers: [prometheus]
-      exporters: [logging, prometheusremotewrite]
+      receivers:
+        - prometheus
+      processors:
+        - resourcedetection/env
+        - resource/deleteUnrequired
+        - resource/rename
+      exporters:
+        - logging
+        - prometheusremotewrite

--- a/tests/test-config.yml
+++ b/tests/test-config.yml
@@ -18,6 +18,11 @@ processors:
     timeout: 2s
     override: true
 
+  resourcedetection/ecs:
+    detectors: [ecs]
+    timeout: 2s
+    override: true
+
   resource/deleteUnrequired:
     attributes:
       - key: net.host.name
@@ -59,6 +64,7 @@ service:
         - prometheus
       processors:
         - resourcedetection/env
+        - resourcedetection/ecs
         - resource/deleteUnrequired
         - resource/rename
       exporters:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -58,8 +58,8 @@ LABEL_RESPONSE=$(curl --no-progress-meter -X GET http://127.0.0.1:9090/api/v1/la
 LABEL=$(jq -r '.data[0]' <<< "$LABEL_RESPONSE")
 
 if [ "$LABEL" != "fooValue2" ]; then
-  echo "ERROR: Labels were not renamed."
-  echo "Received the following reply when querying for fooLabel:"
+  echo "ERROR: fooLabel2 was not added."
+  echo "Received the following reply when querying for fooLabel2:"
   jq <<< "$LABEL_RESPONSE"
   exit 1
 fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -53,6 +53,18 @@ if [ "$LABEL" != "fooValue" ]; then
   exit 1
 fi
 
+echo "Checking label fooLabel2 from the env is not being renamed"
+LABEL_RESPONSE=$(curl --no-progress-meter -X GET http://127.0.0.1:9090/api/v1/label/fooLabel2/values)
+LABEL=$(jq -r '.data[0]' <<< "$LABEL_RESPONSE")
+
+if [ "$LABEL" != "fooValue2" ]; then
+  echo "ERROR: Labels were not renamed."
+  echo "Received the following reply when querying for fooLabel:"
+  jq <<< "$LABEL_RESPONSE"
+  exit 1
+fi
+
+
 echo "Checking values are being sent"
 QUERY_RESPONSE=$(curl --no-progress-meter -X GET http://127.0.0.1:9090/api/v1/query?query=page_count_foo)
 METRIC_VALUE=$(jq -r '.data.result[0].value[1]' <<< "$QUERY_RESPONSE")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -42,6 +42,17 @@ if [ "$LABEL" != "local-test" ]; then
   exit 1
 fi
 
+echo "Checking label fooLabel from the env is being renamed to barLabel"
+LABEL_RESPONSE=$(curl --no-progress-meter -X GET http://127.0.0.1:9090/api/v1/label/barLabel/values)
+LABEL=$(jq -r '.data[0]' <<< "$LABEL_RESPONSE")
+
+if [ "$LABEL" != "fooValue" ]; then
+  echo "ERROR: Labels were not renamed."
+  echo "Received the following reply when querying for fooLabel:"
+  jq <<< "$LABEL_RESPONSE"
+  exit 1
+fi
+
 echo "Checking values are being sent"
 QUERY_RESPONSE=$(curl --no-progress-meter -X GET http://127.0.0.1:9090/api/v1/query?query=page_count_foo)
 METRIC_VALUE=$(jq -r '.data.result[0].value[1]' <<< "$QUERY_RESPONSE")


### PR DESCRIPTION
1. Update to the latest otel collector, superseding https://github.com/alphagov/pay-adot/pull/8
2. Use the env resourcedetection processor to allow us to inject resource attributes via the env
3. Use the ecs resourcedetection processor to gather ECS information
4. Delete everything the ecs detection found apart from the task arn
5. Rename the task arn to match our other labels (to ecsTaskARN)
6. Enable resource to telemetry conversion which will apply the resource attributes as labels to all metrics
7. Fix deprecation warning that we were using `logLevel: info`, change to `verbosity: normal` as suggested in the docs

Edit: This PR (https://github.com/alphagov/pay-infra/pull/4519) adds an OTEL_RESOURCE_ATTRIBUTES env var to populate ecsClusterName, ecsServiceName, containerImageTag, and awsAccountName